### PR TITLE
Added check for comma at the end of paramters, and fixed few crashes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3409,12 +3409,13 @@ public final class TokenTypes {
     /**
      * MaxJ literal DEFAULT
      */
-    public static final int MAXJ_DEFAULT =
-          GeneratedJavaTokenTypes.LITERAL_DEFAULT;
-
+   public static final int MAXJ_DEFAULT =
+          GeneratedJavaTokenTypes.LITERAL_default;
+    
     /**
      * MaxJ literal OTHERWISE
      */
+   
     public static final int MAXJ_OTHERWISE =
           GeneratedJavaTokenTypes.LITERAL_OTHERWISE;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/CommaAtEndCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/CommaAtEndCheck.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.checks;
+
+import com.puppycrawl.tools.checkstyle.api.*;
+
+public class CommaAtEndCheck extends AbstractCheck {
+
+	@Override
+	public int[] getDefaultTokens() {		
+		//On what nodes to run check
+		return new int[]{TokenTypes.METHOD_DEF};
+	}
+	
+	@Override
+    public void visitToken(DetailAST ast) {
+        // find the PARAMETERS node below the METHOD_DEF
+        DetailAST methodBlock = ast.findFirstToken( TokenTypes.PARAMETERS);
+        // Check if last node is COMMA type
+        if (methodBlock == null) {
+        	return;
+        }
+        
+        if (methodBlock.getLastChild() != null && methodBlock.getLastChild().getType() == TokenTypes.COMMA) {
+        	String message = "There should be no comma at the end of function parameters ";
+            log(ast.getLineNo(), message);
+        }
+    }        
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -964,7 +964,7 @@ parameterDeclarationList
     :   (   ( parameterDeclaration )=> parameterDeclaration
             ( options {warnWhenFollowAmbig=false;} :
                 ( COMMA parameterDeclaration ) => COMMA parameterDeclaration )*
-            ( COMMA variableLengthParameterDeclaration )?
+            ( COMMA variableLengthParameterDeclaration )? (COMMA)?
         |
             variableLengthParameterDeclaration
         )?
@@ -1519,7 +1519,8 @@ postfixExpression
             (options{warnWhenFollowAmbig=false;} : DOT^ "class")?
 
             // an array indexing operation
-        |    lb:LBRACK^ {#lb.setType(INDEX_OP);} expression RBRACK
+            
+        |    lb:LBRACK^ {#lb.setType(INDEX_OP);} expression (COLON expression)? RBRACK
 
             // method invocation
             // The next line is not strictly proper; it allows x(3)(4) or


### PR DESCRIPTION
Fixed checkstyle crash on:
 `int a = array[20:30]`
and
`public void function(int arg1, int arg2, ){}` .

Added check for 2nd case.